### PR TITLE
Make Double Anonymous class mixin for ChestBlock use wildcard

### DIFF
--- a/minigames/common/src/main/java/net/casual/championships/common/mixin/gui/ChestBlockMixin.java
+++ b/minigames/common/src/main/java/net/casual/championships/common/mixin/gui/ChestBlockMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 public class ChestBlockMixin {
 	@SuppressWarnings("UnresolvedMixinReference")
 	@ModifyReturnValue(
-		method = "getDisplayName()Lnet/minecraft/network/chat/Component",
+		method = "getDisplayName*",
 		at = @At("RETURN")
 	)
 	private Component onGetChestTitle(Component title) {


### PR DESCRIPTION
This mixin seems to not remap properly at the time being, using a wildcard allows for this mixin to work in dev and release. There should only be one method in the Anonymous class, so it should be pretty safe.