### PR TITLE
Re-enable vanilla spectator teleport packet

### DIFF
--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/UHCMinigame.kt
@@ -418,6 +418,13 @@ class UHCMinigame(
 
     @Listener
     private fun onPlayerSpectatorTeleport(event: PlayerSpectatorTeleportEvent) {
+        val (player, _) = event
+        if (player.isSpectator && this.players.isSpectating(player)) {
+            val target = event.getTarget()
+            if (target is ServerPlayer) {
+                player.teleportTo(target.location)
+            }
+        }
         event.cancel()
     }
 


### PR DESCRIPTION
Useful for client-side mods which use this packet to create spectator menus. Uses the same method as the `/uhc spectate` (or `/s`) commands, so it shouldn't break anything