### PR TITLE
feat: Add config for nerfed players

### DIFF
--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -124,8 +124,6 @@ import net.minecraft.world.effect.MobEffectInstance
 import net.minecraft.world.effect.MobEffects
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
-import net.minecraft.world.entity.ai.attributes.AttributeModifier
-import net.minecraft.world.entity.ai.attributes.Attributes
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import net.minecraft.world.item.alchemy.Potion
@@ -187,19 +185,6 @@ class UHCMinigame(
     }
 
     fun resetPlayerHealth(player: ServerPlayer) {
-        if (this.nerfedPlayers.contains(player.uuid)) run {
-            val maxHealth = player.attributes.getInstance(Attributes.MAX_HEALTH) ?: return@run
-            maxHealth.removeModifier(PLAYER_MAX_HEALTH_NERF_ID)
-            // nerf by halving total health
-            maxHealth.addPermanentModifier(
-                AttributeModifier(
-                    PLAYER_MAX_HEALTH_NERF_ID,
-                    -0.5,
-                    AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL
-                )
-            )
-        }
-
         player.boostHealth(this.settings.health)
         player.resetHealth()
     }
@@ -356,6 +341,7 @@ class UHCMinigame(
         if (!this.players.isSpectating(player)) {
             this.updateBoundaryInfo(player)
             this.updatePedalToTheMetal(player)
+            this.updatePlayerNerfs(player)
         } else if (!player.isCreative) {
             val interval = 20.Minutes.ticks
             if (this.uptime % interval == interval - 1) {
@@ -417,7 +403,6 @@ class UHCMinigame(
     private fun onMinigamePlayerRemoved(event: MinigameRemovePlayerEvent) {
         val player = event.player
         player.unboostHealth()
-        player.attributes.getInstance(Attributes.MAX_HEALTH)?.removeModifier(PLAYER_MAX_HEALTH_NERF_ID)
         player.resetHunger()
         player.resetExperience()
         player.clearPlayerInventory()
@@ -791,6 +776,17 @@ class UHCMinigame(
         ))
     }
 
+    private fun updatePlayerNerfs(player: ServerPlayer) {
+        if (!this.nerfedPlayers.contains(player.uuid)) {
+            return
+        }
+
+        // Not a particularly glamorous way to do this, but it works
+        player.addEffect(MobEffectInstance(
+            MobEffects.WEAKNESS, MobEffectInstance.INFINITE_DURATION, 0, false, false, false
+        ))
+    }
+
     private fun createSidebar(): DynamicSidebar {
         val sidebar = DynamicSidebar(ComponentElements.of(UHCComponents.Bitmap.TITLE))
         val buffer = SpacingFontResources.spaced(4)
@@ -933,8 +929,6 @@ class UHCMinigame(
     companion object {
         private const val MOB_SPAWN_PROBABILITY = 1.0F / 2.0F
         private val MOB_LOOT_MULTIPLIER = (1.0F / MOB_SPAWN_PROBABILITY).roundToInt()
-
-        private val PLAYER_MAX_HEALTH_NERF_ID = UHCMod.id("player_max_health_nerf")
 
         val ID = UHCMod.id("uhc_minigame")
     }

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -124,6 +124,8 @@ import net.minecraft.world.effect.MobEffectInstance
 import net.minecraft.world.effect.MobEffects
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.ai.attributes.AttributeModifier
+import net.minecraft.world.entity.ai.attributes.Attributes
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import net.minecraft.world.item.alchemy.Potion
@@ -153,6 +155,7 @@ class UHCMinigame(
     server: MinecraftServer,
     uuid: UUID,
     private val dimensions: UHCDimensions,
+    private val nerfedPlayers: Set<UUID>,
     private val factory: UHCMinigameFactory? = null
 ): Minigame(server, uuid), RulesProvider by UHCRules {
     override val id = ID
@@ -184,6 +187,19 @@ class UHCMinigame(
     }
 
     fun resetPlayerHealth(player: ServerPlayer) {
+        if (this.nerfedPlayers.contains(player.uuid)) run {
+            val maxHealth = player.attributes.getInstance(Attributes.MAX_HEALTH) ?: return@run
+            maxHealth.removeModifier(PLAYER_MAX_HEALTH_NERF_ID)
+            // nerf by halving total health
+            maxHealth.addPermanentModifier(
+                AttributeModifier(
+                    PLAYER_MAX_HEALTH_NERF_ID,
+                    -0.5,
+                    AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL
+                )
+            )
+        }
+
         player.boostHealth(this.settings.health)
         player.resetHealth()
     }
@@ -401,6 +417,7 @@ class UHCMinigame(
     private fun onMinigamePlayerRemoved(event: MinigameRemovePlayerEvent) {
         val player = event.player
         player.unboostHealth()
+        player.attributes.getInstance(Attributes.MAX_HEALTH)?.removeModifier(PLAYER_MAX_HEALTH_NERF_ID)
         player.resetHunger()
         player.resetExperience()
         player.clearPlayerInventory()
@@ -916,6 +933,8 @@ class UHCMinigame(
     companion object {
         private const val MOB_SPAWN_PROBABILITY = 1.0F / 2.0F
         private val MOB_LOOT_MULTIPLIER = (1.0F / MOB_SPAWN_PROBABILITY).roundToInt()
+
+        private val PLAYER_MAX_HEALTH_NERF_ID = UHCMod.id("player_max_health_nerf")
 
         val ID = UHCMod.id("uhc_minigame")
     }

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigameFactory.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigameFactory.kt
@@ -11,6 +11,7 @@ import net.casual.arcade.minigame.serialization.MinigameCreationContext
 import net.casual.arcade.minigame.serialization.MinigameFactory
 import net.casual.arcade.utils.ResourceUtils
 import net.casual.arcade.utils.codec.CodecProvider
+import net.casual.arcade.utils.setOf
 import net.casual.championships.uhc.utils.UHCDimensions
 import net.minecraft.core.UUIDUtil
 import net.minecraft.core.registries.Registries
@@ -20,7 +21,6 @@ import net.minecraft.util.StringRepresentable
 import net.minecraft.world.level.Level
 import net.minecraft.world.level.levelgen.WorldOptions
 import java.util.*
-import kotlin.collections.HashMap
 
 data class DimensionWithSeed(
     val key: Optional<DimensionWithPersistence>,
@@ -100,7 +100,13 @@ class UHCMinigameFactory(
             this.createLevelWithPersistence(levels, VanillaDimension.End, dimensionsCopy),
         )
         val nerfedPlayersCopy = HashSet(this.nerfedPlayers)
-        return UHCMinigame(context.server, context.uuid, dimensions, nerfedPlayersCopy, UHCMinigameFactory(dimensionsCopy, nerfedPlayersCopy))
+        return UHCMinigame(
+            context.server,
+            context.uuid,
+            dimensions,
+            nerfedPlayersCopy,
+            UHCMinigameFactory(dimensionsCopy, nerfedPlayersCopy)
+        )
     }
 
     private fun randomDimensionKey(dimension: String): ResourceKey<Level> {
@@ -129,8 +135,7 @@ class UHCMinigameFactory(
                     DimensionWithSeed.CODEC,
                     StringRepresentable.keys(VanillaDimension.entries.toTypedArray())
                 ).fieldOf("dimensions").forGetter(UHCMinigameFactory::dimensions),
-                UUIDUtil.CODEC_SET.lenientOptionalFieldOf("nerfed_players", emptySet())
-                    .forGetter(UHCMinigameFactory::nerfedPlayers)
+                UUIDUtil.STRING_CODEC.setOf().lenientOptionalFieldOf("nerfed_players", emptySet()).forGetter(UHCMinigameFactory::nerfedPlayers)
             ).apply(instance, ::UHCMinigameFactory)
         }
     }

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigameFactory.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigameFactory.kt
@@ -12,6 +12,7 @@ import net.casual.arcade.minigame.serialization.MinigameFactory
 import net.casual.arcade.utils.ResourceUtils
 import net.casual.arcade.utils.codec.CodecProvider
 import net.casual.championships.uhc.utils.UHCDimensions
+import net.minecraft.core.UUIDUtil
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.resources.ResourceLocation
@@ -57,21 +58,22 @@ data class DimensionWithSeed(
 }
 
 class UHCMinigameFactory(
-    private val dimensions: Map<VanillaDimension, DimensionWithSeed>
+    private val dimensions: Map<VanillaDimension, DimensionWithSeed>,
+    private val nerfedPlayers: Set<UUID>
 ): MinigameFactory {
     override fun codec(): MapCodec<out MinigameFactory> {
         return CODEC
     }
 
     override fun create(context: MinigameCreationContext): UHCMinigame {
-        val copy = HashMap(this.dimensions)
+        val dimensionsCopy = HashMap(this.dimensions)
         for (entry in VanillaDimension.entries) {
-            copy.putIfAbsent(entry, DimensionWithSeed.DEFAULT)
+            dimensionsCopy.putIfAbsent(entry, DimensionWithSeed.DEFAULT)
         }
 
         val seed = WorldOptions.randomSeed()
         val levels = VanillaLikeLevelsBuilder.build(context.server) {
-            for (entry in copy.entries) {
+            for (entry in dimensionsCopy.entries) {
                 val (dimension, data) = entry
                 val key = data.key.map { it.key }
                     .orElseGet { randomDimensionKey(dimension.getDimensionKey().location().path) }
@@ -81,7 +83,7 @@ class UHCMinigameFactory(
                 val updated = data.copy(
                     key = Optional.of(DimensionWithSeed.DimensionWithPersistence(key, persistence))
                 )
-                copy[dimension] = updated
+                dimensionsCopy[dimension] = updated
 
                 set(dimension) {
                     dimensionKey(key)
@@ -93,11 +95,12 @@ class UHCMinigameFactory(
         }
 
         val dimensions = UHCDimensions(
-            this.createLevelWithPersistence(levels, VanillaDimension.Overworld, copy),
-            this.createLevelWithPersistence(levels, VanillaDimension.Nether, copy),
-            this.createLevelWithPersistence(levels, VanillaDimension.End, copy),
+            this.createLevelWithPersistence(levels, VanillaDimension.Overworld, dimensionsCopy),
+            this.createLevelWithPersistence(levels, VanillaDimension.Nether, dimensionsCopy),
+            this.createLevelWithPersistence(levels, VanillaDimension.End, dimensionsCopy),
         )
-        return UHCMinigame(context.server, context.uuid, dimensions, UHCMinigameFactory(copy))
+        val nerfedPlayersCopy = HashSet(this.nerfedPlayers)
+        return UHCMinigame(context.server, context.uuid, dimensions, nerfedPlayersCopy, UHCMinigameFactory(dimensionsCopy, nerfedPlayersCopy))
     }
 
     private fun randomDimensionKey(dimension: String): ResourceKey<Level> {
@@ -125,7 +128,9 @@ class UHCMinigameFactory(
                     VanillaDimension.CODEC,
                     DimensionWithSeed.CODEC,
                     StringRepresentable.keys(VanillaDimension.entries.toTypedArray())
-                ).fieldOf("dimensions").forGetter(UHCMinigameFactory::dimensions)
+                ).fieldOf("dimensions").forGetter(UHCMinigameFactory::dimensions),
+                UUIDUtil.CODEC_SET.lenientOptionalFieldOf("nerfed_players", emptySet())
+                    .forGetter(UHCMinigameFactory::nerfedPlayers)
             ).apply(instance, ::UHCMinigameFactory)
         }
     }


### PR DESCRIPTION
Example config:
```json5
{
  // ...
  "minigames": [
    {
      "type": "casual_uhc:uhc_minigame",
      "dimensions": {
        // ...
      },
      "nerfed_players": [
        [1722778085, 780553320, -1795315810, 196999911], // iHatred
        [2085685811, -25279576, -1399119807, 652467454], // Erikbacke
        [2059644209, -503824061, -2051101675, -410672090], // eztaK_red
        [-1823321100, 1889095222, -1930291001, 1879149687] // Actevitus
      ]
    }
  ]
  // ...
}
```