### PR TITLE
Fix Portals Failing to Link no Matter if a Valid Portal is Near

### DIFF
--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/border/UHCBoundaryPhase.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/border/UHCBoundaryPhase.kt
@@ -3,6 +3,7 @@ package net.casual.championships.uhc.border
 import net.casual.arcade.boundary.LevelBoundary
 import net.casual.arcade.utils.TimeUtils.Minutes
 import net.casual.arcade.utils.time.MinecraftTimeDuration
+import net.casual.arcade.utils.time.MinecraftTimeUnit
 import net.minecraft.core.Direction
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.level.levelgen.Heightmap
@@ -22,7 +23,7 @@ sealed class UHCBoundaryPhase(
         return LevelBoundary.SizeAndCenter(this.getEndSize(level), this.getEndCenter(level))
     }
 
-    fun getSpeed(level: ServerLevel): Double {
+    fun getSpeedInBlocksPerTick(level: ServerLevel): Double {
         val start = this.getStartSize(level)
         val end = this.getEndSize(level)
         val dx = abs(start.x - end.x)

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -697,7 +697,7 @@ class UHCMinigame(
     }
 
     private fun isPositionValidForPortal(level: ServerLevel, position: BlockPos, boundary: LevelBoundary): Boolean {
-        // Blocks per millisecond
+        // Blocks per tick
         val shrinkingSpeed = this.boundaryPhase.getSpeedInBlocksPerTick(level)
         if (shrinkingSpeed <= 0) {
             // The border is static or expanding

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -303,8 +303,8 @@ class UHCMinigame(
 
         val boundary = level.levelBoundary ?: return
 
-        // Blocks per millisecond
-        val shrinkingSpeed = this.boundaryPhase.getSpeed(level)
+        // Blocks per tick
+        val shrinkingSpeed = this.boundaryPhase.getSpeedInBlocksPerTick(level)
         if (shrinkingSpeed > 0) {
             val box = boundary.getAABB()
             event.cancel(BlockPos.containing(
@@ -315,7 +315,7 @@ class UHCMinigame(
             return
         }
 
-        val margin = shrinkingSpeed * this.settings.portalEscapeTime.milliseconds
+        val margin = shrinkingSpeed * this.settings.portalEscapeTime.ticks
         if (margin >= boundary.getSize().x * 0.5) {
             val (x, y, z) = boundary.getCenter()
             // The border would reach size 0 within 30 seconds
@@ -698,13 +698,13 @@ class UHCMinigame(
 
     private fun isPositionValidForPortal(level: ServerLevel, position: BlockPos, boundary: LevelBoundary): Boolean {
         // Blocks per millisecond
-        val shrinkingSpeed = this.boundaryPhase.getSpeed(level)
+        val shrinkingSpeed = this.boundaryPhase.getSpeedInBlocksPerTick(level)
         if (shrinkingSpeed <= 0) {
             // The border is static or expanding
             return boundary.contains(position) == BoundaryShape.Containment.Full
         }
 
-        val margin = shrinkingSpeed * this.settings.portalEscapeTime.milliseconds
+        val margin = shrinkingSpeed * this.settings.portalEscapeTime.ticks
         val size = boundary.getSize()
         val xMargin = margin.coerceAtMost(size.x * 0.5 - 1)
         val yMargin = margin.coerceAtMost(size.y * 0.5 - 1)

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -303,7 +303,6 @@ class UHCMinigame(
 
         val boundary = level.levelBoundary ?: return
 
-        // Blocks per tick
         val shrinkingSpeed = this.boundaryPhase.getSpeedInBlocksPerTick(level)
         if (shrinkingSpeed > 0) {
             val box = boundary.getAABB()
@@ -697,7 +696,6 @@ class UHCMinigame(
     }
 
     private fun isPositionValidForPortal(level: ServerLevel, position: BlockPos, boundary: LevelBoundary): Boolean {
-        // Blocks per tick
         val shrinkingSpeed = this.boundaryPhase.getSpeedInBlocksPerTick(level)
         if (shrinkingSpeed <= 0) {
             // The border is static or expanding


### PR DESCRIPTION
The getSpeed() method uses ticks, but calculations had treated its value in the units of `blocks/milisecond`.
This PR gives a more descriptive name: `getSpeed` -> `getSpeedInBlocksPerTick`