### PR TITLE
Fix UHC Spawn being at y `-64`

### DIFF
--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -127,6 +127,8 @@ import net.minecraft.network.protocol.game.ClientboundTickingStepPacket
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.level.Ticket
+import net.minecraft.server.level.TicketType
 import net.minecraft.tags.BlockTags
 import net.minecraft.util.Mth
 import net.minecraft.world.effect.MobEffectInstance
@@ -142,6 +144,7 @@ import net.minecraft.world.item.alchemy.Potions
 import net.minecraft.world.item.crafting.RecipeType
 import net.minecraft.world.item.crafting.SingleRecipeInput
 import net.minecraft.world.item.enchantment.Enchantments
+import net.minecraft.world.level.ChunkPos
 import net.minecraft.world.level.ClipContext
 import net.minecraft.world.level.GameType
 import net.minecraft.world.level.levelgen.Heightmap
@@ -272,6 +275,8 @@ class UHCMinigame(
         this.advancements.addAll(UHCAdvancements)
         this.settings.enableChatCommand.set(true)
 
+        this.overworld.chunkSource.addTicket(Ticket(TicketType.SPAWN_SEARCH, 1), ChunkPos(0,0))
+        this.overworld.tick { true }
         val y =  this.overworld.getHeight(Heightmap.Types.WORLD_SURFACE, 0, 0)
         this.levels.spawn = MinigameLevelManager.SpawnLocation.global(
             location = this.overworld.asLocation(Vec3(0.0, y.toDouble(), 0.0)),

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -275,8 +275,8 @@ class UHCMinigame(
         this.advancements.addAll(UHCAdvancements)
         this.settings.enableChatCommand.set(true)
 
-        this.overworld.chunkSource.addTicket(Ticket(TicketType.SPAWN_SEARCH, 1), ChunkPos(0,0))
-        this.overworld.tick { true }
+        // Force load the chunk at 0, 0 so we can load the heightmap
+        this.overworld.getChunk(0, 0)
         val y =  this.overworld.getHeight(Heightmap.Types.WORLD_SURFACE, 0, 0)
         this.levels.spawn = MinigameLevelManager.SpawnLocation.global(
             location = this.overworld.asLocation(Vec3(0.0, y.toDouble(), 0.0)),


### PR DESCRIPTION
This PR makes `onInitialize` load and tick the chunk at (0, 0) to generate its true heightmap before setting the minigame spawn point.

This fixes an issue where any player who leaves the end will spawn under the bedrock.

