### PR TITLE
Improve the algorithm for finding a UHC (re)spawn location

### DIFF
--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -67,6 +67,7 @@ import net.casual.arcade.utils.TimeUtils.formatMMSS
 import net.casual.arcade.utils.component.*
 import net.casual.arcade.utils.impl.Sound
 import net.casual.arcade.utils.math.location.Location.Companion.withRotation
+import net.casual.arcade.utils.math.location.LocationWithLevel
 import net.casual.arcade.utils.math.location.LocationWithLevel.Companion.asLocation
 import net.casual.arcade.utils.math.location.LocationWithLevel.Companion.locationWithLevel
 import net.casual.arcade.utils.time.MinecraftTimeDuration
@@ -113,10 +114,12 @@ import net.casual.championships.uhc.recipe.HeavyCoreRecipe
 import net.casual.championships.uhc.utils.UHCComponents
 import net.casual.championships.uhc.utils.UHCDimensions
 import net.casual.championships.uhc.utils.UHCMinigameRules
+import net.casual.championships.uhc.utils.UHCSpreadTeleporter
 import net.casual.championships.uhc.utils.UHCStats
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBlockTags
 import net.minecraft.ChatFormatting
 import net.minecraft.ChatFormatting.*
+import net.minecraft.commands.arguments.EntityAnchorArgument
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.core.Holder
@@ -127,8 +130,6 @@ import net.minecraft.network.protocol.game.ClientboundTickingStepPacket
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
-import net.minecraft.server.level.Ticket
-import net.minecraft.server.level.TicketType
 import net.minecraft.tags.BlockTags
 import net.minecraft.util.Mth
 import net.minecraft.world.effect.MobEffectInstance
@@ -144,7 +145,6 @@ import net.minecraft.world.item.alchemy.Potions
 import net.minecraft.world.item.crafting.RecipeType
 import net.minecraft.world.item.crafting.SingleRecipeInput
 import net.minecraft.world.item.enchantment.Enchantments
-import net.minecraft.world.level.ChunkPos
 import net.minecraft.world.level.ClipContext
 import net.minecraft.world.level.GameType
 import net.minecraft.world.level.levelgen.Heightmap
@@ -275,13 +275,7 @@ class UHCMinigame(
         this.advancements.addAll(UHCAdvancements)
         this.settings.enableChatCommand.set(true)
 
-        // Force load the chunk at 0, 0 so we can load the heightmap
-        this.overworld.getChunk(0, 0)
-        val y =  this.overworld.getHeight(Heightmap.Types.WORLD_SURFACE, 0, 0)
-        this.levels.spawn = MinigameLevelManager.SpawnLocation.global(
-            location = this.overworld.asLocation(Vec3(0.0, y.toDouble(), 0.0)),
-            overridesPlayerSpawnPoint = true
-        )
+        this.levels.spawn = UHCSpawnLocation()
 
         this.visuals.setSidebar(this.createSidebar())
     }
@@ -1000,6 +994,51 @@ class UHCMinigame(
 
     private fun isFinalStage(level: ServerLevel): Boolean {
         return UHCBoundaryManager.getFinalPhase(this, level) <= this.boundaryPhase
+    }
+
+    private inner class UHCSpawnLocation: MinigameLevelManager.SpawnLocation {
+        override val overridesPlayerSpawnPoint: Boolean = true
+
+        override fun get(player: ServerPlayer): LocationWithLevel<ServerLevel> {
+            val location = this.getValidRespawnPos(player) ?:
+                    overworld.asLocation(overworld.levelBoundary?.getCenter() ?: Vec3.ZERO)
+            val level = location.level
+            val pos = location.position
+
+            return UHCSpreadTeleporter.tryFindPosition(BlockPos.containing(pos), level)?.let {
+                val centerPos = it.bottomCenter
+                level.levelBoundary?.let { boundary ->
+                    val rotation = player.createCommandSourceStack()
+                                         .withAnchor(EntityAnchorArgument.Anchor.EYES)
+                                         .withPosition(centerPos)
+                                         .facing(boundary.getCenter()).rotation
+                    level.asLocation(centerPos, rotation)
+                } ?: level.asLocation(centerPos)
+            } ?: run {
+                val blockPos = BlockPos.containing(pos)
+                // Force load the chunk so we can load the heightmap
+                level.getChunk(blockPos)
+                val y = level.getHeight(Heightmap.Types.WORLD_SURFACE, blockPos.x, blockPos.z)
+                level.asLocation(pos.with(Direction.Axis.Y, y.toDouble()))
+            }
+        }
+
+        private fun getValidRespawnPos(player: ServerPlayer): LocationWithLevel<ServerLevel>? {
+            val respawnData = player.respawnConfig?.respawnData ?: return null
+            val level = server.getLevel(respawnData.dimension()) ?: return null
+            if (!levels.has(level)) return null
+
+            val respawnPos = respawnData.pos().bottomCenter
+            val boundary = level.levelBoundary ?: return level.asLocation(respawnPos)
+            if (boundary.contains(respawnPos)) {
+                return level.asLocation(respawnPos)
+            }
+
+            val factor = 0.99 // nudge the player further inside the border
+            val inBorderPos = boundary.shape.getDirectionFrom(respawnPos)
+                .add(respawnPos).scale(factor)
+            return level.asLocation(inBorderPos)
+        }
     }
 
     private inner class BorderMovingInfo(private val buffer: Component): LevelSpecificElement<SidebarComponent> {

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCMinigame.kt
@@ -23,7 +23,6 @@ import net.casual.arcade.minigame.annotation.ListenerFlags.IS_PLAYING
 import net.casual.arcade.minigame.events.*
 import net.casual.arcade.minigame.gamemode.ExtendedGameMode
 import net.casual.arcade.minigame.gamemode.ExtendedGameMode.Companion.extendedGameMode
-import net.casual.arcade.minigame.managers.MinigameLevelManager
 import net.casual.arcade.minigame.serialization.MinigameFactory
 import net.casual.arcade.minigame.stats.Stat.Companion.increment
 import net.casual.arcade.minigame.utils.MinigameUtils.addEventListener
@@ -67,7 +66,6 @@ import net.casual.arcade.utils.TimeUtils.formatMMSS
 import net.casual.arcade.utils.component.*
 import net.casual.arcade.utils.impl.Sound
 import net.casual.arcade.utils.math.location.Location.Companion.withRotation
-import net.casual.arcade.utils.math.location.LocationWithLevel
 import net.casual.arcade.utils.math.location.LocationWithLevel.Companion.asLocation
 import net.casual.arcade.utils.math.location.LocationWithLevel.Companion.locationWithLevel
 import net.casual.arcade.utils.time.MinecraftTimeDuration
@@ -114,12 +112,10 @@ import net.casual.championships.uhc.recipe.HeavyCoreRecipe
 import net.casual.championships.uhc.utils.UHCComponents
 import net.casual.championships.uhc.utils.UHCDimensions
 import net.casual.championships.uhc.utils.UHCMinigameRules
-import net.casual.championships.uhc.utils.UHCSpreadTeleporter
 import net.casual.championships.uhc.utils.UHCStats
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBlockTags
 import net.minecraft.ChatFormatting
 import net.minecraft.ChatFormatting.*
-import net.minecraft.commands.arguments.EntityAnchorArgument
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.core.Holder
@@ -275,7 +271,7 @@ class UHCMinigame(
         this.advancements.addAll(UHCAdvancements)
         this.settings.enableChatCommand.set(true)
 
-        this.levels.spawn = UHCSpawnLocation()
+        this.levels.spawn = UHCSpawnLocation(this)
 
         this.visuals.setSidebar(this.createSidebar())
     }
@@ -994,51 +990,6 @@ class UHCMinigame(
 
     private fun isFinalStage(level: ServerLevel): Boolean {
         return UHCBoundaryManager.getFinalPhase(this, level) <= this.boundaryPhase
-    }
-
-    private inner class UHCSpawnLocation: MinigameLevelManager.SpawnLocation {
-        override val overridesPlayerSpawnPoint: Boolean = true
-
-        override fun get(player: ServerPlayer): LocationWithLevel<ServerLevel> {
-            val location = this.getValidRespawnPos(player) ?:
-                    overworld.asLocation(overworld.levelBoundary?.getCenter() ?: Vec3.ZERO)
-            val level = location.level
-            val pos = location.position
-
-            return UHCSpreadTeleporter.tryFindPosition(BlockPos.containing(pos), level)?.let {
-                val centerPos = it.bottomCenter
-                level.levelBoundary?.let { boundary ->
-                    val rotation = player.createCommandSourceStack()
-                                         .withAnchor(EntityAnchorArgument.Anchor.EYES)
-                                         .withPosition(centerPos)
-                                         .facing(boundary.getCenter()).rotation
-                    level.asLocation(centerPos, rotation)
-                } ?: level.asLocation(centerPos)
-            } ?: run {
-                val blockPos = BlockPos.containing(pos)
-                // Force load the chunk so we can load the heightmap
-                level.getChunk(blockPos)
-                val y = level.getHeight(Heightmap.Types.WORLD_SURFACE, blockPos.x, blockPos.z)
-                level.asLocation(pos.with(Direction.Axis.Y, y.toDouble()))
-            }
-        }
-
-        private fun getValidRespawnPos(player: ServerPlayer): LocationWithLevel<ServerLevel>? {
-            val respawnData = player.respawnConfig?.respawnData ?: return null
-            val level = server.getLevel(respawnData.dimension()) ?: return null
-            if (!levels.has(level)) return null
-
-            val respawnPos = respawnData.pos().bottomCenter
-            val boundary = level.levelBoundary ?: return level.asLocation(respawnPos)
-            if (boundary.contains(respawnPos)) {
-                return level.asLocation(respawnPos)
-            }
-
-            val factor = 0.99 // nudge the player further inside the border
-            val inBorderPos = boundary.shape.getDirectionFrom(respawnPos)
-                .add(respawnPos).scale(factor)
-            return level.asLocation(inBorderPos)
-        }
     }
 
     private inner class BorderMovingInfo(private val buffer: Component): LevelSpecificElement<SidebarComponent> {

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCSpawnLocation.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/minigame/UHCSpawnLocation.kt
@@ -1,0 +1,61 @@
+package net.casual.championships.uhc.minigame
+
+import net.casual.arcade.boundary.extension.LevelBoundaryExtension.Companion.levelBoundary
+import net.casual.arcade.minigame.managers.MinigameLevelManager
+import net.casual.arcade.utils.MathUtils.rotationAnglesTowards
+import net.casual.arcade.utils.math.location.LocationWithLevel
+import net.casual.arcade.utils.math.location.LocationWithLevel.Companion.asLocation
+import net.casual.championships.uhc.utils.UHCSpreadTeleporter
+import net.minecraft.core.BlockPos
+import net.minecraft.core.Direction
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.level.levelgen.Heightmap
+import net.minecraft.world.phys.Vec2
+import net.minecraft.world.phys.Vec3
+
+class UHCSpawnLocation(
+    private val uhc: UHCMinigame
+): MinigameLevelManager.SpawnLocation {
+    override val overridesPlayerSpawnPoint: Boolean = true
+
+    override fun get(player: ServerPlayer): LocationWithLevel<ServerLevel> {
+        val location = this.getValidRespawnPos(player) ?:
+        this.uhc.overworld.asLocation(this.uhc.overworld.levelBoundary?.getCenter() ?: Vec3.ZERO)
+        val level = location.level
+        val pos = location.position
+
+        val valid = UHCSpreadTeleporter.searchForValidPosition(BlockPos.containing(pos), level)
+        if (valid != null) {
+            val centerPos = valid.bottomCenter
+            val boundary = level.levelBoundary
+            val rotation = if (boundary != null) player.eyePosition.rotationAnglesTowards(boundary.getCenter()) else Vec2.ZERO
+            return level.asLocation(centerPos, rotation)
+        }
+
+        val blockPos = BlockPos.containing(pos)
+        // Force load the chunk so we can load the heightmap
+        level.getChunk(blockPos)
+        val y = level.getHeight(Heightmap.Types.WORLD_SURFACE, blockPos.x, blockPos.z)
+        return level.asLocation(pos.with(Direction.Axis.Y, y.toDouble()))
+    }
+
+    private fun getValidRespawnPos(player: ServerPlayer): LocationWithLevel<ServerLevel>? {
+        val respawnData = player.respawnConfig?.respawnData ?: return null
+        val level = this.uhc.server.getLevel(respawnData.dimension()) ?: return null
+        if (!this.uhc.levels.has(level)) {
+            return null
+        }
+
+        val respawnPos = respawnData.pos().bottomCenter
+        val boundary = level.levelBoundary ?: return level.asLocation(respawnPos)
+        if (boundary.contains(respawnPos)) {
+            return level.asLocation(respawnPos)
+        }
+
+        val factor = 0.99 // nudge the player further inside the border
+        val inBorderPos = boundary.shape.getDirectionFrom(respawnPos)
+            .add(respawnPos).scale(factor)
+        return level.asLocation(inBorderPos)
+    }
+}

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/utils/UHCSpreadTeleporter.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/utils/UHCSpreadTeleporter.kt
@@ -40,15 +40,9 @@ object UHCSpreadTeleporter: ShapedTeleporter() {
 
     override fun teleportTeam(team: PlayerTeam, entities: Collection<Entity>, location: LocationWithLevel<ServerLevel>) {
         val level = location.level
-        val boundary = level.levelBoundary
         val origin = BlockPos.containing(location.position)
-        val positions = BlockPosUtils.dispersed(origin, 20, 100, 8, Direction.Axis.Y)
-        for (position in positions) {
-            val adjusted = getTopNonCollidingPos(level, position)
-            if (adjusted == null || (boundary != null && !boundary.contains(adjusted.center))) {
-                continue
-            }
-            super.teleportTeam(team, entities, level.asLocation(adjusted.center, location.rotation))
+        tryFindPosition(origin, level)?.let {
+            super.teleportTeam(team, entities, level.asLocation(it.center, location.rotation))
             return
         }
 
@@ -79,6 +73,19 @@ object UHCSpreadTeleporter: ShapedTeleporter() {
         return MapCodec.unit(this)
     }
 
+    fun tryFindPosition(origin: BlockPos, level: ServerLevel): BlockPos? {
+        val boundary = level.levelBoundary
+        val positions = BlockPosUtils.dispersed(origin, 20, 100, 8, Direction.Axis.Y)
+        for (position in positions) {
+            val adjusted = getTopNonCollidingPos(level, position)
+            if (adjusted == null || (boundary != null && !boundary.contains(adjusted.center))) {
+                continue
+            }
+            return adjusted
+        }
+        return null
+    }
+
     private fun getTopNonCollidingPos(level: ServerLevel, initial: BlockPos): BlockPos? {
         val chunk = level.getChunk(initial)
         val y = level.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, initial.x, initial.z)
@@ -88,9 +95,9 @@ object UHCSpreadTeleporter: ShapedTeleporter() {
                 pos.move(Direction.DOWN)
             } while (!chunk.getBlockState(pos).isAir)
 
-            do {
+            while (chunk.getBlockState(pos.below()).isAir && pos.y > level.minY) {
                 pos.move(Direction.DOWN)
-            } while (chunk.getBlockState(pos).isAir && pos.y > level.minY)
+            }
         }
 
         val adjusted = SpawnPlacementTypes.ON_GROUND.adjustSpawnPosition(level, pos.immutable())

--- a/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/utils/UHCSpreadTeleporter.kt
+++ b/minigames-uhc/src/main/kotlin/net/casual/championships/uhc/utils/UHCSpreadTeleporter.kt
@@ -38,11 +38,25 @@ object UHCSpreadTeleporter: ShapedTeleporter() {
     private val netherSpawn by lazy { StructureUtils.read(structurePath.resolve("nether_spawn.nbt")) }
     private val endSpawn by lazy { StructureUtils.read(structurePath.resolve("end_spawn.nbt")) }
 
+    fun searchForValidPosition(origin: BlockPos, level: ServerLevel): BlockPos? {
+        val boundary = level.levelBoundary
+        val positions = BlockPosUtils.dispersed(origin, 20, 100, 8, Direction.Axis.Y)
+        for (position in positions) {
+            val adjusted = getTopNonCollidingPos(level, position)
+            if (adjusted == null || (boundary != null && !boundary.contains(adjusted.center))) {
+                continue
+            }
+            return adjusted
+        }
+        return null
+    }
+
     override fun teleportTeam(team: PlayerTeam, entities: Collection<Entity>, location: LocationWithLevel<ServerLevel>) {
         val level = location.level
         val origin = BlockPos.containing(location.position)
-        tryFindPosition(origin, level)?.let {
-            super.teleportTeam(team, entities, level.asLocation(it.center, location.rotation))
+        val valid = searchForValidPosition(origin, level)
+        if (valid != null) {
+            super.teleportTeam(team, entities, level.asLocation(valid.center, location.rotation))
             return
         }
 
@@ -71,19 +85,6 @@ object UHCSpreadTeleporter: ShapedTeleporter() {
 
     override fun codec(): MapCodec<out EntityTeleporter> {
         return MapCodec.unit(this)
-    }
-
-    fun tryFindPosition(origin: BlockPos, level: ServerLevel): BlockPos? {
-        val boundary = level.levelBoundary
-        val positions = BlockPosUtils.dispersed(origin, 20, 100, 8, Direction.Axis.Y)
-        for (position in positions) {
-            val adjusted = getTopNonCollidingPos(level, position)
-            if (adjusted == null || (boundary != null && !boundary.contains(adjusted.center))) {
-                continue
-            }
-            return adjusted
-        }
-        return null
     }
 
     private fun getTopNonCollidingPos(level: ServerLevel, initial: BlockPos): BlockPos? {


### PR DESCRIPTION
Prior to this, it would've been very easy to set up a trap for players returning from the end, as the spawn position was highly predictable by the adversary.

Now, we try to spawn the player at their bed/anchor position, or the nearest position to it inside the border. Otherwise, we will attempt to spawn the player somewhere near the border's center while utilizing the spawning criteria used by most entities to at least avoid the most primitive traps (e.g. lava).

An off-by-one bug in the `getTopNonCollidingPos()` method has also been fixed. In dimensions with a ceiling (the Nether) it used to plant players into the ground.